### PR TITLE
[v2] support BOSH v2 schemas and 'bosh create-env' specificities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,118 @@
 Humanize BOSH Manifest
 ======================
 
-Convert a BOSH deployment manifest created by Spiff (keys are alphabetically sorted) into a readable format.
+Convert a BOSH deployment manifest created by `bosh interpolate` (where keys
+are sorted in alphabetical order) into a human-friendly readable format.
+
+The latests BOSH v2.0 deployment manifest schema is primarily supported, but
+v1 is also supported, and `bosh create-env` (formely known as `bosh-init`)
+specificities are also supported.
+
+This also basically works for old v1 manifests created by `spiff` or `spruce`
+because v1 manifest schema is supported. But only BOSH schema is kept in
+output, so any `meta` YAML tree will be removed from output, which would be an
+issue with intermetidate manifests where the `meta` node was common practice
+and critical to later steps in the manifest build chain.
+
 
 Usage
 -----
 
-```
-humanize-manifest manifest.yml > readable_manifest.yml
-```
-
-Without an argument the it will use the currently targeted deployment manifest (from `~/.bosh_config`\)
+The command just takes a manifest as argument and writes the result to the
+standard output.
 
 ```
-bosh deployment path/to/manifest.yml
-humanize-manifest
+humanize-manifest machine-created-manifest.yml > human-readable-manifest.yml
 ```
 
-The output will vary based on the manifest, but here is an example from a bosh-lite CF manifest:
+The output will vary based on the manifest, but here is an example with a
+[SHIELD v8](https://github.com/starkandwayne/shield-boshrelease) deployment
+manifests from the [Easy Foundry distribution](https://github.com/gstackio/gstack-bosh-environment):
 
-```
-$ humanize-manifest | head -n 20
-meta:
-  default_env:
-    bosh:
-      password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0
-  environment: cf-warden
-  releases:
-  - name: cf
-    version: latest
-  stemcell:
-    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
-    version: latest
-name: cf-warden
-director_uuid: c6f166bd-ddac-4f7d-9c57-d11c6ad5133b
+```yaml
+name: easyfoundry-shield-v8  # name comes first
+instance_groups:
+- name: shield               # name comes first
+  instances: 1
+  azs: [z1]                  # AZs are folded
+  jobs:
+  - name: core
+    release: shield
+    provides:
+      shield:
+        as: shield
+        shared: true
+    properties:
+      # ...
+  - name: shield-agent
+    release: shield
+    consumes:
+      shield:
+        instances:
+        - address: shield-v8.easyfoundry.internal
+        properties:
+          domain: shield-v8.easyfoundry.internal
+          port: 10443
+    properties:
+      core:
+        ca: ((shield-tls.ca))
+  stemcell: default
+  vm_type: default
+  vm_extensions:
+  - shield-v8-loadbalancer
+  persistent_disk_type: 1GB
+  networks:
+  - name: shield-v8-network
+update:
+  serial: true
+  canary_watch_time: 1000-120000
+  max_in_flight: 1
+  update_watch_time: 1000-120000
+variables:
+- name: shield-agent-key
+  type: ssh
+- name: shield-ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: shieldca
+- name: shield-tls
+  type: certificate
+  options:
+    ca: shield-ca
+    common_name: shield
+    alternative_names:
+    - 127.0.0.1
+    - '*.shield.default.shield.bosh'
+    - '*.shield.shield-v8-network.easyfoundry-shield-v8.bosh'
+    - shield-v8.easyfoundry.prototyp.it
+    extended_key_usage: [client_auth, server_auth]
+- name: vault-ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: vaultca
+- name: vault-tls
+  type: certificate
+  options:
+    ca: vault-ca
+    common_name: vault
+    alternative_names:
+    - 127.0.0.1
+    - '*.vault.default.shield.bosh'
+    - '*.vault.shield-v8-network.easyfoundry-shield-v8.bosh'
+    extended_key_usage: [client_auth, server_auth]
 releases:
-- name: cf
-  version: "200"
-compilation:
-  workers: 6
-  network: cf1
-  reuse_compilation_vms: true
+- name: shield
+  version: 8.0.8
+  url: https://github.com/starkandwayne/shield-boshrelease/releases/download/v8.0.8/shield-8.0.8.tgz
+  sha1: 55d1d6d8557f9b185fef7b5c6d73017b4c654f03
+stemcells:
+- alias: default
+  os: ubuntu-trusty
+  version: "3541.9"
 ```
+
 
 Install
 -------

--- a/main.go
+++ b/main.go
@@ -5,11 +5,19 @@ import (
 	"io/ioutil"
 	"os"
 
-	"launchpad.net/goyaml"
-
-	"github.com/cloudfoundry-community/gogobosh/local"
-	"github.com/cloudfoundry-community/gogobosh/models"
+	"gopkg.in/yaml.v2"
 )
+
+type Manifest struct {
+	Name         string    `yaml:"name"`
+	DirectorUUID string    `yaml:"director_uuid"`
+	Releases     []Release `yaml:"releases"`
+}
+
+type Release struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
 
 func fatalIf(err error) {
 	if err != nil {
@@ -18,26 +26,18 @@ func fatalIf(err error) {
 	}
 }
 
-func currentBoshManifest() string {
-	configPath, err := local.DefaultBoshConfigPath()
-	fatalIf(err)
-	config, err := local.LoadBoshConfig(configPath)
-	fatalIf(err)
-	return config.CurrentDeploymentManifest()
-}
-
 func main() {
 	manifestPath := os.Args[1]
 	if manifestPath == "" {
-		manifestPath = currentBoshManifest()
+		os.Exit(2)
 	}
 
 	contents, err := ioutil.ReadFile(manifestPath)
 	fatalIf(err)
-	manifest := &models.DeploymentManifest{}
-	goyaml.Unmarshal(contents, manifest)
+	manifest := &Manifest{}
+	yaml.Unmarshal(contents, manifest)
 
-	str, err := goyaml.Marshal(*manifest)
+	str, err := yaml.Marshal(*manifest)
 	fatalIf(err)
 	fmt.Println(string(str))
 }

--- a/main.go
+++ b/main.go
@@ -9,14 +9,168 @@ import (
 )
 
 type Manifest struct {
-	Name         string    `yaml:"name"`
-	DirectorUUID string    `yaml:"director_uuid"`
-	Releases     []Release `yaml:"releases"`
+	Name           string              `yaml:"name,omitempty"` // Ref: https://bosh.io/docs/manifest-v2/#deployment
+	DirectorUUID   string              `yaml:"director_uuid,omitempty"`
+	Tags           interface{}         `yaml:"tags,omitempty"` // Ref: https://bosh.io/docs/manifest-v2/#tags
+	InstanceGroups []InstanceGroup     `yaml:"instance_groups,omitempty"`
+	Jobs           []InstanceGroup     `yaml:"jobs,omitempty"`     // deprecated v1 alias for 'instance_groups'
+	Features       interface{}         `yaml:"features,omitempty"` // Ref: https://bosh.io/docs/manifest-v2/#features
+	Update         Update              `yaml:"update,omitempty"`
+	Addons         []Addon             `yaml:"addons,omitempty"`
+	Properties     interface{}         `yaml:"properties,omitempty"`     // v1. Deprecated in favor of job properties
+	Networks       []NetworkDefinition `yaml:"networks,omitempty"`       // v1. Obsoleted by Cloud-Config, but useful for 'create-env'
+	ResourcePools  []VMProfile         `yaml:"resource_pools,omitempty"` // v1. Obsoleted by Cloud-Config, but useful for 'create-env'
+	DiskPools      []DiskProfile       `yaml:"disk_pools,omitempty"`     // v1. Obsoleted by Cloud-Config, but useful for 'create-env'
+	Compilation    CompilationConfig   `yaml:"compilation,omitempty"`    // v1. Obsoleted by Cloud-Config, but useful for 'create-env'
+	CloudProvider  CPIConfig           `yaml:"cloud_provider,omitempty"` // Only valid with 'create-env' (a.k.a. bosh-init)
+	Variables      []Variable          `yaml:"variables,omitempty"`
+	Releases       []Release           `yaml:"releases,omitempty"`
+	Stemcells      []Stemcell          `yaml:"stemcells,omitempty"`
 }
 
+// Ref: https://bosh.io/docs/manifest-v2/#instance-groups
+type InstanceGroup struct {
+	Name               string        `yaml:"name,omitempty"`
+	MigratedFrom       []string      `yaml:"migrated_from,omitempty"`
+	Instances          int           `yaml:"instances,omitempty"`
+	Lifecycle          string        `yaml:"lifecycle,omitempty"`
+	AZs                []string      `yaml:"azs,omitempty,flow"`
+	Jobs               []Job         `yaml:"jobs,omitempty"`
+	Templates          []Job         `yaml:"templates,omitempty"`  // deprecated v1 alias for 'jobs'
+	Properties         interface{}   `yaml:"properties,omitempty"` // v1. Deprecated in favor of job properties
+	Stemcell           string        `yaml:"stemcell,omitempty"`
+	VMType             string        `yaml:"vm_type,omitempty"`
+	ResourcePool       string        `yaml:"resource_pool,omitempty"` // v1 concept similar to 'vm_type'
+	VMExtensions       []interface{} `yaml:"vm_extensions,omitempty"`
+	VMResources        []interface{} `yaml:"vm_resources,omitempty"`
+	PersistentDisk     int           `yaml:"persistent_disk,omitempty"`
+	PersistentDiskType string        `yaml:"persistent_disk_type,omitempty"`
+	PersistentDiskPool string        `yaml:"persistent_disk_pool,omitempty"` // v1 concept similar to 'persistent_disk_type'
+	Env                interface{}   `yaml:"env,omitempty"`
+	Networks           []Network     `yaml:"networks,omitempty"`
+	Update             Update        `yaml:"update,omitempty"`
+}
+
+type Job struct {
+	Name       string      `yaml:"name,omitempty"`
+	Release    string      `yaml:"release,omitempty"`
+	Provides   interface{} `yaml:"provides,omitempty"`
+	Consumes   interface{} `yaml:"consumes,omitempty"`
+	Properties interface{} `yaml:"properties,omitempty"`
+}
+
+type Network struct {
+	Name      string   `yaml:"name,omitempty"`
+	Default   []string `yaml:"default,omitempty,flow"`
+	StaticIPs []string `yaml:"static_ips,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/manifest-v2/#update
+type Update struct {
+	Serial          bool   `yaml:"serial,omitempty"`
+	Canaries        int    `yaml:"canaries,omitempty"`
+	CanaryWatchTime string `yaml:"canary_watch_time,omitempty"`
+	MaxInFlight     int    `yaml:"max_in_flight,omitempty"`
+	UpdateWatchTime string `yaml:"update_watch_time,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/manifest-v2/#addons
+type Addon struct {
+	Name    string      `yaml:"name,omitempty"`
+	Jobs    []Job       `yaml:"jobs,omitempty"`
+	Include interface{} `yaml:"include,omitempty"`
+	Exclude interface{} `yaml:"exclude,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/deployment-manifest/#networks
+type NetworkDefinition struct {
+	Name            string             `yaml:"name,omitempty"` // 'manual', 'dynamic', or 'vip'
+	Type            string             `yaml:"type,omitempty"`
+	DNS             []string           `yaml:"dns,omitempty,flow"` // for 'dynamic' networks with no subnets only
+	Subnets         []SubnetDefinition `yaml:"subnets,omitempty"`  // for 'manual' or 'dynamic' networks only
+	CloudProperties interface{}        `yaml:"cloud_properties,omitempty"`
+}
+
+type SubnetDefinition struct {
+	Range           string      `yaml:"range,omitempty"`   // for 'manual' networks only
+	Gateway         string      `yaml:"gateway,omitempty"` // for 'manual' networks only
+	DNS             []string    `yaml:"dns,omitempty,flow"`
+	Reserved        []string    `yaml:"reserved,omitempty"` // for 'manual' networks only
+	Static          []string    `yaml:"static,omitempty"`   // for 'manual' networks only
+	AZ              string      `yaml:"az,omitempty"`
+	AZs             []string    `yaml:"azs,omitempty,flow"`
+	CloudProperties interface{} `yaml:"cloud_properties,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/deployment-manifest/#resource-pools
+type VMProfile struct {
+	Name            string                `yaml:"name,omitempty"`
+	Network         string                `yaml:"network,omitempty"`
+	Size            int                   `yaml:"size,omitempty"`
+	Stemcell        BoshCreateEnvStemcell `yaml:"stemcell,omitempty"`
+	CloudProperties interface{}           `yaml:"cloud_properties,omitempty"`
+	Env             interface{}           `yaml:"env,omitempty"`
+}
+
+type BoshCreateEnvStemcell struct {
+	URL  string `yaml:"url,omitempty"`
+	SHA1 string `yaml:"sha1,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/deployment-manifest/#disk-pools
+type DiskProfile struct {
+	Name            string      `yaml:"nam,omitempty"`
+	DiskSize        int         `yaml:"disk_size,omitempty"`
+	CloudProperties interface{} `yaml:"cloud_properties,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/deployment-manifest/#compilation
+type CompilationConfig struct {
+	Workers             int         `yaml:"workers,omitempty"`
+	Network             string      `yaml:"network,omitempty"`
+	ReuseCompilationVMs bool        `yaml:"reuse_compilation_vms,omitempty"`
+	CloudProperties     interface{} `yaml:"cloud_properties,omitempty"`
+}
+
+type CPIConfig struct {
+	Template   interface{} `yaml:"template,omitempty"`
+	MBus       string      `yaml:"mbus,omitempty"`
+	Cert       string      `yaml:"cert,omitempty"`
+	Properties interface{} `yaml:"properties,omitempty"`
+}
+
+// Ref: https://bosh.io/docs/manifest-v2/#variables
+type Variable struct {
+	Name    string          `yaml:"name,omitempty"`
+	Type    string          `yaml:"type,omitempty"`
+	Options VariableOptions `yaml:"options,omitempty"`
+}
+
+type VariableOptions struct {
+	IsCA             bool     `yaml:"is_ca,omitempty"`
+	CA               string   `yaml:"ca,omitempty"`
+	CommonName       string   `yaml:"common_name,omitempty"`
+	AlternativeNames []string `yaml:"alternative_names,omitempty"`
+	ExtendedKeyUsage []string `yaml:"extended_key_usage,omitempty,flow"`
+}
+
+// Ref. v2: https://bosh.io/docs/manifest-v2/#releases
+//
+// Ref. v1: https://bosh.io/docs/deployment-manifest/#releases
+// Ref. v1: https://bosh.io/docs/deployment-manifest/#bosh-init-stemcells
 type Release struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name    string `yaml:"name,omitempty"`
+	Version string `yaml:"version,omitempty"`
+	URL     string `yaml:"url,omitempty"`
+	SHA1    string `yaml:"sha1,omitempty"`
+}
+
+// Ref. v2: https://bosh.io/docs/manifest-v2/#stemcells
+type Stemcell struct {
+	Alias   string `yaml:"alias,omitempty"`
+	Name    string `yaml:"name,omitempty"` // 'alias' is preferred over 'name'
+	Os      string `yaml:"os,omitempty"`
+	Version string `yaml:"version,omitempty"`
 }
 
 func fatalIf(err error) {


### PR DESCRIPTION
Hi Dr Nic!

I like this project because it is helpful when debugging intermediate steps of a `bosh int` tool chain like I will implement in the near future for the [Gstack BOSH Environment](https://github.com/gstackio/gstack-bosh-environment) framework.

So, I updated this `humanize-manifest` tool in order to support newer v2 schemas.

Feel free to make any comments, or whatever feels relevant to you.

Best,